### PR TITLE
Restores example nat.ml by removing "test_conj"

### DIFF
--- a/examples/nat/bin/main.ml
+++ b/examples/nat/bin/main.ml
@@ -46,20 +46,12 @@ let nat_add_commut =
         ];
     ]
 
-let test_conj =
-  to_proofs
-    [ block "Conjuction property of Bool"
-        [ prop "andb_true"
-            ~context:(forall [("b", "boolean")])
-            (( atom "andb b True" =.= atom "b" >> case "b")
-            &^ (atom "andb True b" =.= atom "b" >> straight) ) ] ]
-
 let () =
   if Array.length Sys.argv = 2 then
     let filename = Sys.argv.(1) in
     Out_channel.with_file ~append:true ~fail_if_exists:false filename
       ~f:(fun out ->
         let fmt = formatter_of_out_channel out in
-        generate_proof fmt test_conj;
+        generate_proof fmt nat_add_commut;
         close_out out)
   else fprintf err_formatter "target file name missing"


### PR DESCRIPTION
Should fix issue https://github.com/marigold-dev/easier-proofs/issues/4

All examples and tests are now correctly working.